### PR TITLE
Refactor search navigation to use slug for media selection; streamlin…

### DIFF
--- a/web/src/components/Header/Search/Results.tsx
+++ b/web/src/components/Header/Search/Results.tsx
@@ -1,8 +1,6 @@
 import { Book, FileQuestion, Film, Tv } from 'lucide-react';
 import { MediaType, SearchMediaByQuery } from 'types/graphql';
 
-import { navigate, routes } from '@redwoodjs/router';
-
 import { cn } from 'src/utils/cn';
 
 import { useSearchNavigation } from './useSearchNavigation';
@@ -16,7 +14,8 @@ export const Result = ({
   index: number;
   media: SearchMediaByQuery['medias'][number];
 }) => {
-  const { setOpen } = useSearchNavigation();
+  // Get handleSelect from the hook
+  const { handleSelect } = useSearchNavigation();
 
   const getMediaIcon = (type: MediaType) => {
     switch (type) {
@@ -31,18 +30,12 @@ export const Result = ({
     }
   };
 
-  const handleSelect = () => {
-    setOpen(false);
-    navigate(
-      routes.media({
-        id: media.slug,
-      })
-    );
-  };
+  // Removed local handleSelect function
 
   return (
     <button
-      onClick={() => handleSelect()}
+      // Call the handleSelect from the hook with the slug
+      onClick={() => handleSelect(media.slug)}
       className={cn(
         'flex w-full items-start gap-3 px-4 py-2 text-left',
         index === selectedIndex

--- a/web/src/components/Header/Search/useSearchNavigation.tsx
+++ b/web/src/components/Header/Search/useSearchNavigation.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from 'react';
 
-import { navigate } from '@redwoodjs/router';
+import { navigate, routes } from '@redwoodjs/router';
 
 const useSearchNavigation = () => {
   const context = useContext(SearchNavigationContext);
@@ -17,16 +17,17 @@ const SearchNavigationContext = createContext({
   setSelectedIndex: (_index: number) => {},
   open: false,
   setOpen: (_open: boolean) => {},
-  handleSelect: (_mediaId: string) => {},
+  handleSelect: (_slug: string) => {},
 });
 
 const SearchNavigationProvider = ({ children }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [open, setOpen] = useState(false);
 
-  const handleSelect = (mediaId: string) => {
+  const handleSelect = (slug: string) => {
     setOpen(false);
-    navigate(`/media/${mediaId}`);
+    // Use the Redwood routes helper for consistency
+    navigate(routes.media({ id: slug }));
   };
 
   return (


### PR DESCRIPTION
…e handleSelect logic in Results component

This pull request includes updates to the `Search` functionality in the `Header` component. The changes primarily involve refactoring the `handleSelect` function to be managed by the `useSearchNavigation` hook and ensuring consistency in navigation using the Redwood routes helper.

Refactoring and consistency improvements:

* [`web/src/components/Header/Search/Results.tsx`](diffhunk://#diff-e00a63d5c11bc17697798ac9a5bff66a00967b8325e90a4a15d8a8e97a9a2aafL19-R18): Removed the local `handleSelect` function and updated the `onClick` handler to use the `handleSelect` function from the `useSearchNavigation` hook. [[1]](diffhunk://#diff-e00a63d5c11bc17697798ac9a5bff66a00967b8325e90a4a15d8a8e97a9a2aafL19-R18) [[2]](diffhunk://#diff-e00a63d5c11bc17697798ac9a5bff66a00967b8325e90a4a15d8a8e97a9a2aafL34-R38)
* [`web/src/components/Header/Search/Results.tsx`](diffhunk://#diff-e00a63d5c11bc17697798ac9a5bff66a00967b8325e90a4a15d8a8e97a9a2aafL4-L5): Removed unused imports for `navigate` and `routes`.
* [`web/src/components/Header/Search/useSearchNavigation.tsx`](diffhunk://#diff-e7823ed85952cac9269f688d99920097f619244ce268a0eb4206b3188b3a43beL3-R3): Added the `routes` import and updated the `handleSelect` function to use the Redwood routes helper for navigation. [[1]](diffhunk://#diff-e7823ed85952cac9269f688d99920097f619244ce268a0eb4206b3188b3a43beL3-R3) [[2]](diffhunk://#diff-e7823ed85952cac9269f688d99920097f619244ce268a0eb4206b3188b3a43beL20-R30)