### PR TITLE
Refactor ActivityForm to use constants for activity types; remove unu…

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -16,6 +16,6 @@
 [api]
   port = 8911
 [browser]
-  open = true
+  open = false
 [notifications]
   versionUpdates = ["latest"]

--- a/web/src/components/Activity/ActivityForm/ActivityForm.tsx
+++ b/web/src/components/Activity/ActivityForm/ActivityForm.tsx
@@ -1,4 +1,3 @@
-import { ActivityType } from '@prisma/client';
 import { format } from 'date-fns';
 import { CalendarIcon, Check, ChevronsUpDown, Save } from 'lucide-react';
 import type { EditActivityById, UpdateActivityInput } from 'types/graphql';
@@ -44,8 +43,9 @@ import {
   PopoverTrigger,
 } from 'src/components/ui/popover';
 import { useActivityModal } from 'src/layouts/ProvidersLayout/Providers/ActivityProvider';
-import { formatPrismaEnum } from 'src/lib/formatters';
 import { cn } from 'src/utils/cn';
+
+import { activityTypes } from './constants';
 
 type FormActivity = NonNullable<EditActivityById['activity']>;
 
@@ -141,14 +141,14 @@ const ActivityForm = (props: ActivityFormProps) => {
                           variant="outline"
                           role="combobox"
                           className={cn(
-                            'col-span-3 justify-between',
+                            'col-span-3 justify-between lowercase',
                             !field.value && 'text-muted-foreground'
                           )}
                         >
                           {field.value
-                            ? formatPrismaEnum(ActivityType).find(
-                                activity => activity.value === field.value
-                              )?.label
+                            ? activityTypes.find(
+                                activity => activity === field.value
+                              )
                             : 'Select activity'}
                           <ChevronsUpDown className="size-4 opacity-50" />
                         </Button>
@@ -163,19 +163,21 @@ const ActivityForm = (props: ActivityFormProps) => {
                         <CommandList>
                           <CommandEmpty>No activity found.</CommandEmpty>
                           <CommandGroup>
-                            {formatPrismaEnum(ActivityType).map(activity => (
+                            {activityTypes.map(activity => (
                               <CommandItem
-                                value={activity.value}
-                                key={activity.value}
+                                value={activity}
+                                key={activity}
+                                className="lowercase"
                                 onSelect={() => {
-                                  form.setValue('activityType', activity.value);
+                                  form.setValue('activityType', activity);
+                                  form.setFocus('duration');
                                 }}
                               >
-                                {activity.label}
+                                {activity}
                                 <Check
                                   className={cn(
                                     'ml-auto size-4',
-                                    activity.value === field.value
+                                    activity === field.value
                                       ? 'opacity-100'
                                       : 'opacity-0'
                                   )}

--- a/web/src/components/Activity/ActivityForm/constants.ts
+++ b/web/src/components/Activity/ActivityForm/constants.ts
@@ -1,0 +1,12 @@
+import { ActivityType } from 'types/graphql';
+
+export const activityTypes: ActivityType[] = [
+  'WATCHING',
+  'READING',
+  'LISTENING',
+  'GRAMMAR',
+  'VOCABULARY',
+  'WRITING',
+  'PLAYING',
+  'OTHER',
+];

--- a/web/src/lib/formatters.tsx
+++ b/web/src/lib/formatters.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import humanize from 'humanize-string';
 
 const MAX_STRING_LENGTH = 150;
@@ -55,18 +53,4 @@ export const timeTag = (dateTime?: string) => {
 
 export const checkboxInputTag = (checked: boolean) => {
   return <input type="checkbox" checked={checked} disabled />;
-};
-
-export const formatPrismaEnum = <T extends Record<string, string>>(
-  enumObj: T
-): Array<{
-  value: T[keyof T]; // This preserves the literal types from the enum
-  label: string;
-}> => {
-  return Object.entries(enumObj).map(([key, value]) => ({
-    value: value as T[keyof T], // Cast to preserve the enum literal type
-    label:
-      key.charAt(0).toUpperCase() +
-      key.slice(1).toLowerCase().replace(/_/g, ' '),
-  }));
 };


### PR DESCRIPTION
…sed formatPrismaEnum function and update related logic

This pull request includes several changes to the `ActivityForm` component, the `constants` file, and the `redwood.toml` configuration file. The most important changes include updating the `ActivityForm` to use a new `activityTypes` constant, removing the `formatPrismaEnum` function, and modifying the browser configuration in `redwood.toml`.

Changes to `ActivityForm` component:

* [`web/src/components/Activity/ActivityForm/ActivityForm.tsx`](diffhunk://#diff-2c848e9e2daee5ef0436107d88208b29fdf82148174f639073a4ef28737547d8L1): Removed the import of `ActivityType` and `formatPrismaEnum`, added the import of `activityTypes` from the new `constants` file, and updated the component to use `activityTypes` instead of `formatPrismaEnum` for activity selection. [[1]](diffhunk://#diff-2c848e9e2daee5ef0436107d88208b29fdf82148174f639073a4ef28737547d8L1) [[2]](diffhunk://#diff-2c848e9e2daee5ef0436107d88208b29fdf82148174f639073a4ef28737547d8L47-R49) [[3]](diffhunk://#diff-2c848e9e2daee5ef0436107d88208b29fdf82148174f639073a4ef28737547d8L144-R151) [[4]](diffhunk://#diff-2c848e9e2daee5ef0436107d88208b29fdf82148174f639073a4ef28737547d8L166-R180)

Changes to `constants` file:

* [`web/src/components/Activity/ActivityForm/constants.ts`](diffhunk://#diff-3b0e86ec4c2973d4dab0a53b720bc3d7b92150aa58ce019623da80dffeee33b4R1-R12): Added a new `activityTypes` constant which is an array of activity type strings.

Changes to `formatters` file:

* [`web/src/lib/formatters.tsx`](diffhunk://#diff-39bccb5dee472e370f7f9f320c87328fee424be70887be78c3a1018d1ce04fa2L1-L2): Removed the `formatPrismaEnum` function as it is no longer needed. [[1]](diffhunk://#diff-39bccb5dee472e370f7f9f320c87328fee424be70887be78c3a1018d1ce04fa2L1-L2) [[2]](diffhunk://#diff-39bccb5dee472e370f7f9f320c87328fee424be70887be78c3a1018d1ce04fa2L59-L72)

Changes to configuration:

* [`redwood.toml`](diffhunk://#diff-95c2a8b81365df24f9f12b4f86e8efa85f0df31ca11dea37f69e045f28735ec1L19-R19): Modified the browser configuration to not open automatically by setting `open` to `false`.