### PR TITLE
Refactor FormErrorMessage component to simplify props handling and im…

### DIFF
--- a/redwood.toml
+++ b/redwood.toml
@@ -16,6 +16,6 @@
 [api]
   port = 8911
 [browser]
-  open = true
+  open = false
 [notifications]
   versionUpdates = ["latest"]

--- a/web/src/components/Activity/ActivityForm/ActivityForm.tsx
+++ b/web/src/components/Activity/ActivityForm/ActivityForm.tsx
@@ -1,4 +1,3 @@
-import { ActivityType } from '@prisma/client';
 import { format } from 'date-fns';
 import { CalendarIcon, Check, ChevronsUpDown, Save } from 'lucide-react';
 import type { EditActivityById, UpdateActivityInput } from 'types/graphql';
@@ -44,8 +43,9 @@ import {
   PopoverTrigger,
 } from 'src/components/ui/popover';
 import { useActivityModal } from 'src/layouts/ProvidersLayout/Providers/ActivityProvider';
-import { formatPrismaEnum } from 'src/lib/formatters';
 import { cn } from 'src/utils/cn';
+
+import { activityTypes } from './constants';
 
 type FormActivity = NonNullable<EditActivityById['activity']>;
 
@@ -141,14 +141,14 @@ const ActivityForm = (props: ActivityFormProps) => {
                           variant="outline"
                           role="combobox"
                           className={cn(
-                            'col-span-3 justify-between',
+                            'col-span-3 justify-between lowercase',
                             !field.value && 'text-muted-foreground'
                           )}
                         >
                           {field.value
-                            ? formatPrismaEnum(ActivityType).find(
-                                activity => activity.value === field.value
-                              )?.label
+                            ? activityTypes.find(
+                                activity => activity === field.value
+                              )
                             : 'Select activity'}
                           <ChevronsUpDown className="size-4 opacity-50" />
                         </Button>
@@ -163,19 +163,21 @@ const ActivityForm = (props: ActivityFormProps) => {
                         <CommandList>
                           <CommandEmpty>No activity found.</CommandEmpty>
                           <CommandGroup>
-                            {formatPrismaEnum(ActivityType).map(activity => (
+                            {activityTypes.map(activity => (
                               <CommandItem
-                                value={activity.value}
-                                key={activity.value}
+                                value={activity}
+                                key={activity}
+                                className="lowercase"
                                 onSelect={() => {
-                                  form.setValue('activityType', activity.value);
+                                  form.setValue('activityType', activity);
+                                  form.setFocus('duration');
                                 }}
                               >
-                                {activity.label}
+                                {activity}
                                 <Check
                                   className={cn(
                                     'ml-auto size-4',
-                                    activity.value === field.value
+                                    activity === field.value
                                       ? 'opacity-100'
                                       : 'opacity-0'
                                   )}

--- a/web/src/components/Activity/ActivityForm/constants.ts
+++ b/web/src/components/Activity/ActivityForm/constants.ts
@@ -1,0 +1,12 @@
+import { ActivityType } from 'types/graphql';
+
+export const activityTypes: ActivityType[] = [
+  'WATCHING',
+  'READING',
+  'LISTENING',
+  'GRAMMAR',
+  'VOCABULARY',
+  'WRITING',
+  'PLAYING',
+  'OTHER',
+];

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -147,17 +147,16 @@ const FormMessage = React.forwardRef<
 });
 FormMessage.displayName = 'FormMessage';
 
-const FormErrorMessage = React.forwardRef<
-  React.ElementRef<typeof FormError>,
-  React.ComponentPropsWithoutRef<typeof FormError>
->(({ ...props }) => {
+const FormErrorMessage = (
+  props: React.ComponentPropsWithoutRef<typeof FormError>
+) => {
   return (
     <FormError
       wrapperClassName="text-destructive text-sm font-medium"
       {...props}
     />
   );
-});
+};
 FormErrorMessage.displayName = 'FormErrorMessage';
 
 export {

--- a/web/src/lib/formatters.tsx
+++ b/web/src/lib/formatters.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import humanize from 'humanize-string';
 
 const MAX_STRING_LENGTH = 150;
@@ -55,18 +53,4 @@ export const timeTag = (dateTime?: string) => {
 
 export const checkboxInputTag = (checked: boolean) => {
   return <input type="checkbox" checked={checked} disabled />;
-};
-
-export const formatPrismaEnum = <T extends Record<string, string>>(
-  enumObj: T
-): Array<{
-  value: T[keyof T]; // This preserves the literal types from the enum
-  label: string;
-}> => {
-  return Object.entries(enumObj).map(([key, value]) => ({
-    value: value as T[keyof T], // Cast to preserve the enum literal type
-    label:
-      key.charAt(0).toUpperCase() +
-      key.slice(1).toLowerCase().replace(/_/g, ' '),
-  }));
 };


### PR DESCRIPTION
…prove readability

This pull request includes a small change to the `FormErrorMessage` component in the `web/src/components/ui/form.tsx` file. The change simplifies the component by removing the use of `React.forwardRef` and directly defining the component as a function.

Changes to `FormErrorMessage` component:

* [`web/src/components/ui/form.tsx`](diffhunk://#diff-f70acfb0624ef8aac8ca3d6cd3d02dac81e48e6e31aaa8d44b56603f9f72a652L150-R159): Simplified the `FormErrorMessage` component by removing `React.forwardRef` and defining it as a function.