### PR TITLE
Add imgProxy utility for image URL handling; update MediaDetails to u…

### DIFF
--- a/web/src/components/Media/MediaDetails.tsx
+++ b/web/src/components/Media/MediaDetails.tsx
@@ -2,6 +2,8 @@ import { formatDate } from 'date-fns';
 import { Book, Calendar, Eye, Film, Tv } from 'lucide-react';
 import { FindMediaQuery, MediaType } from 'types/graphql';
 
+import { imgProxy } from 'src/utils/img-proxy';
+
 import { Button } from '../ui/button';
 
 const MediaDetails = ({ media }: FindMediaQuery) => {
@@ -34,7 +36,12 @@ const MediaDetails = ({ media }: FindMediaQuery) => {
           <img
             // src={media.coverImage || '/placeholder.svg'}
             // alt={media.title}
-            src={media.posterUrl}
+            src={imgProxy({
+              url: media.posterUrl,
+              width: 608,
+              height: 912,
+              fit: 'cover',
+            })}
             alt="placeholder"
             className="object-cover"
           />

--- a/web/src/utils/img-proxy.ts
+++ b/web/src/utils/img-proxy.ts
@@ -1,0 +1,28 @@
+const imgProxyUrl = process.env.IMG_PROXY_URL || 'https://wsrv.nl/';
+
+type ImgProxyFit = 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
+
+interface ImgProxyProps {
+  url: string;
+  width?: number;
+  height?: number;
+  fit?: ImgProxyFit;
+}
+
+const defaultImgProxy: ImgProxyProps = {
+  url: '',
+  width: 900,
+  height: 600,
+  fit: 'cover' as 'cover' | 'contain' | 'fill' | 'inside' | 'outside',
+};
+
+const imgProxy = ({
+  url,
+  width = defaultImgProxy.width,
+  height = defaultImgProxy.height,
+  fit = defaultImgProxy.fit,
+}: ImgProxyProps) => {
+  return `${imgProxyUrl}?url=${encodeURIComponent(url)}&w=${width}&h=${height}&fit=${fit}`;
+};
+
+export { imgProxy };


### PR DESCRIPTION
…se imgProxy for poster images

This pull request includes changes to the `MediaDetails` component and the addition of a new utility function to handle image proxying. The most important changes include importing the new `imgProxy` utility, updating the `MediaDetails` component to use this utility for image URLs, and defining the `imgProxy` function in a new file.

Changes to `MediaDetails` component:

* [`web/src/components/Media/MediaDetails.tsx`](diffhunk://#diff-b3638ec9c82baf2437faf3b820a117194ae4380f8650ab66ea57209bd3c7a9b3R5-R6): Imported the `imgProxy` utility function to handle image URLs.
* [`web/src/components/Media/MediaDetails.tsx`](diffhunk://#diff-b3638ec9c82baf2437faf3b820a117194ae4380f8650ab66ea57209bd3c7a9b3L37-R44): Updated the `src` attribute of the image element to use the `imgProxy` function for generating the image URL with specified dimensions and fit.

Addition of `imgProxy` utility function:

* [`web/src/utils/img-proxy.ts`](diffhunk://#diff-3a69dd1491e84e9d63727a4d754b4502814d37dea9ea5967079a40aa7f6f77ccR1-R28): Defined the `imgProxy` function to generate URLs for images with specified dimensions and fit using a proxy service.