### PR TITLE
Total time

### DIFF
--- a/api/src/graphql/activities.sdl.ts
+++ b/api/src/graphql/activities.sdl.ts
@@ -34,12 +34,18 @@ export const schema = gql`
     bestStreak: Int!
   }
 
+  type TotalTime {
+    totalTime: Int!
+    vsLastWeek: Int!
+  }
+
   type Query {
     activities: [Activity!]! @requireAuth
     activity(id: String!): Activity @requireAuth
     heatMap: [HeatMap!]! @requireAuth
     streak: Streak! @requireAuth
     completedToday: Boolean! @requireAuth
+    totalTime: TotalTime! @requireAuth
   }
 
   input CreateActivityInput {

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
@@ -27,7 +27,7 @@ const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
           <div>
             <div className="mb-1 flex items-center gap-2">
               <Clock className="text-brand-600 dark:text-brand-400 h-5 w-5" />
-              <h3 className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
+              <h3 className="text-sm font-medium text-neutral-600 dark:text-neutral-800">
                 Total Immersion Time
               </h3>
             </div>
@@ -51,7 +51,7 @@ const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
                 {isPositiveChange ? '+' : ''}
                 {totalTime.vsLastWeek}%
               </span>
-              <span className="text-neutral-500 dark:text-neutral-400">
+              <span className="text-neutral-500 dark:text-neutral-800">
                 vs. last week
               </span>
             </div>

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
@@ -1,7 +1,10 @@
 import { Clock, TrendingUp } from 'lucide-react';
-import { GetTotalTimeQuery } from 'types/graphql';
+import { GetTotalTimeQuery, GetTotalTimeQueryVariables } from 'types/graphql';
+
+import { CellFailureProps } from '@redwoodjs/web';
 
 import { Card, CardContent } from 'src/components/ui/card';
+import { cn } from 'src/utils/cn';
 
 const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
   // format the total time from minutes to hours and minutes
@@ -33,7 +36,10 @@ const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
             </p>
             <div className="mt-1 flex items-center gap-1 text-sm">
               <TrendingUp
-                className={`h-4 w-4 ${isPositiveChange ? 'text-green-500' : 'text-red-500'}`}
+                className={cn(
+                  isPositiveChange ? 'text-green-500' : 'text-red-500',
+                  'h-4 w-4'
+                )}
               />
               <span
                 className={
@@ -56,4 +62,50 @@ const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
   );
 };
 
-export default TotalTimeCard;
+const TotalTimeCardLoading = () => (
+  <Card className="bg-brand-50 dark:bg-brand-50 h-[108px]"></Card>
+);
+
+const TotalTimeCardEmpty = () => (
+  <Card className="bg-brand-50 dark:bg-brand-50">
+    <CardContent className="p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <Clock className="text-brand-600 dark:text-brand-400 h-5 w-5" />
+            <h3 className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
+              Total Immersion Time
+            </h3>
+          </div>
+          <p className="text-brand-700 dark:text-brand-300 text-3xl font-bold">
+            0h 0m
+          </p>
+          <div className="mt-1 flex items-center gap-1 text-sm">
+            <TrendingUp className={cn('text-green-500', 'h-4 w-4')} />
+            <span className={'text-green-600 dark:text-green-400'}>+ 0%</span>
+            <span className="text-neutral-500 dark:text-neutral-400">
+              vs. last week
+            </span>
+          </div>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const TotalTimeCardError = ({
+  error,
+}: CellFailureProps<GetTotalTimeQueryVariables>) => (
+  <Card className="bg-brand-50 dark:bg-brand-50 h-[108px]">
+    <CardContent className="p-4">
+      <p className="text-destructive text-sm">{error.message}</p>
+    </CardContent>
+  </Card>
+);
+
+export {
+  TotalTimeCard,
+  TotalTimeCardEmpty,
+  TotalTimeCardError,
+  TotalTimeCardLoading,
+};

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx
@@ -1,0 +1,59 @@
+import { Clock, TrendingUp } from 'lucide-react';
+import { GetTotalTimeQuery } from 'types/graphql';
+
+import { Card, CardContent } from 'src/components/ui/card';
+
+const TotalTimeCard = ({ totalTime }: GetTotalTimeQuery) => {
+  // format the total time from minutes to hours and minutes
+  const formatMinutesToHoursAndMinutes = (totalMinutes: number): string => {
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.round(totalMinutes % 60);
+    return `${hours}h ${minutes}m`;
+  };
+
+  const formattedTime = formatMinutesToHoursAndMinutes(
+    Number(totalTime.totalTime)
+  );
+
+  const isPositiveChange = Number(totalTime.vsLastWeek) >= 0;
+
+  return (
+    <Card className="bg-brand-50 dark:bg-brand-50">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="mb-1 flex items-center gap-2">
+              <Clock className="text-brand-600 dark:text-brand-400 h-5 w-5" />
+              <h3 className="text-sm font-medium text-neutral-600 dark:text-neutral-400">
+                Total Immersion Time
+              </h3>
+            </div>
+            <p className="text-brand-700 dark:text-brand-300 text-3xl font-bold">
+              {formattedTime}
+            </p>
+            <div className="mt-1 flex items-center gap-1 text-sm">
+              <TrendingUp
+                className={`h-4 w-4 ${isPositiveChange ? 'text-green-500' : 'text-red-500'}`}
+              />
+              <span
+                className={
+                  isPositiveChange
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-red-600 dark:text-red-400'
+                }
+              >
+                {isPositiveChange ? '+' : ''}
+                {totalTime.vsLastWeek}%
+              </span>
+              <span className="text-neutral-500 dark:text-neutral-400">
+                vs. last week
+              </span>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TotalTimeCard;

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCell.mock.ts
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCell.mock.ts
@@ -1,0 +1,9 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  totalTime: {
+    __typename: 'TotalTime' as const,
+    id: 42,
+    totalTime: 130,
+    vsLastWeek: 10,
+  },
+});

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCell.stories.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCell.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Loading, Empty, Failure, Success } from './TotalTimeCell';
+import { standard } from './TotalTimeCell.mock';
+
+const meta: Meta = {
+  title: 'Cells/TotalTimeCell',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const loading: StoryObj<typeof Loading> = {
+  render: () => {
+    return Loading ? <Loading /> : <></>;
+  },
+};
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>;
+  },
+};
+
+export const failure: StoryObj<typeof Failure> = {
+  render: args => {
+    return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>;
+  },
+};
+
+export const success: StoryObj<typeof Success> = {
+  render: args => {
+    return Success ? <Success {...standard()} {...args} /> : <></>;
+  },
+};

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCell.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCell.tsx
@@ -9,7 +9,12 @@ import type {
   TypedDocumentNode,
 } from '@redwoodjs/web';
 
-import TotalTimeCard from './TotalTimeCard';
+import {
+  TotalTimeCard,
+  TotalTimeCardEmpty,
+  TotalTimeCardError,
+  TotalTimeCardLoading,
+} from './TotalTimeCard';
 
 export const QUERY: TypedDocumentNode<
   GetTotalTimeQuery,
@@ -23,14 +28,14 @@ export const QUERY: TypedDocumentNode<
   }
 `;
 
-export const Loading = () => <div>Loading...</div>;
+export const Loading = () => <TotalTimeCardLoading />;
 
-export const Empty = () => <div>Empty</div>;
+export const Empty = () => <TotalTimeCardEmpty />;
 
 export const Failure = ({
   error,
 }: CellFailureProps<GetTotalTimeQueryVariables>) => (
-  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+  <TotalTimeCardError error={error} />
 );
 
 export const Success = ({

--- a/web/src/components/Home/TotalTimeCell/TotalTimeCell.tsx
+++ b/web/src/components/Home/TotalTimeCell/TotalTimeCell.tsx
@@ -1,0 +1,40 @@
+import type {
+  GetTotalTimeQuery,
+  GetTotalTimeQueryVariables,
+} from 'types/graphql';
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypedDocumentNode,
+} from '@redwoodjs/web';
+
+import TotalTimeCard from './TotalTimeCard';
+
+export const QUERY: TypedDocumentNode<
+  GetTotalTimeQuery,
+  GetTotalTimeQueryVariables
+> = gql`
+  query GetTotalTimeQuery {
+    totalTime {
+      totalTime
+      vsLastWeek
+    }
+  }
+`;
+
+export const Loading = () => <div>Loading...</div>;
+
+export const Empty = () => <div>Empty</div>;
+
+export const Failure = ({
+  error,
+}: CellFailureProps<GetTotalTimeQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+);
+
+export const Success = ({
+  totalTime,
+}: CellSuccessProps<GetTotalTimeQuery, GetTotalTimeQueryVariables>) => {
+  return <TotalTimeCard totalTime={totalTime} />;
+};

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -3,6 +3,7 @@ import { Metadata } from '@redwoodjs/web';
 
 import HeatMapCell from 'src/components/Home/HeatMapCell';
 import StreakCell from 'src/components/Home/StreakCell';
+import TotalTimeCell from 'src/components/Home/TotalTimeCell';
 
 const HomePage = () => {
   return (
@@ -31,6 +32,7 @@ const HomePage = () => {
 
         <div className="grid gap-6 md:grid-cols-2">
           <StreakCell />
+          <TotalTimeCell />
         </div>
       </div>
     </>


### PR DESCRIPTION
This pull request introduces a new feature to track and display the total immersion time and its comparison to the previous week. The changes span across GraphQL schema, backend services, and frontend components.

### Backend Changes:

* [`api/src/graphql/activities.sdl.ts`](diffhunk://#diff-638d1ad69a0ccfb43f8108219ab38e58658a4f0f18254755aac65234f2572a15R37-R48): Added `TotalTime` type and `totalTime` query to the GraphQL schema.
* [`api/src/services/activities/activities.ts`](diffhunk://#diff-ed240cd8798892b5242aaae357a9811f3bd06d8552144e25decc21bb45571d00R191-R247): Implemented `totalTime` query resolver to calculate total immersion time and percentage change compared to last week.

### Frontend Changes:

* [`web/src/components/Home/TotalTimeCell/TotalTimeCard.tsx`](diffhunk://#diff-c65d6583abbc4fb7d2e96cf45a121b779212f35ba968b84a93863c1dda98df9dR1-R111): Created a new `TotalTimeCard` component to display total immersion time and its comparison to the previous week.
* [`web/src/components/Home/TotalTimeCell/TotalTimeCell.tsx`](diffhunk://#diff-f37cd873a855e9683ba85af20ae86d28dcc35e605bc16a7deec01cf871253b72R1-R45): Defined the GraphQL query and cell states (Loading, Empty, Failure, Success) for the `TotalTimeCell`.
* [`web/src/pages/HomePage/HomePage.tsx`](diffhunk://#diff-205cce25823da0a1f3279386df9bfd8627b1d693b5de2f4c4038331fcf0af5c4R6): Integrated `TotalTimeCell` into the `HomePage` component. [[1]](diffhunk://#diff-205cce25823da0a1f3279386df9bfd8627b1d693b5de2f4c4038331fcf0af5c4R6) [[2]](diffhunk://#diff-205cce25823da0a1f3279386df9bfd8627b1d693b5de2f4c4038331fcf0af5c4R35)