### PR TITLE
Fix heatmap

### DIFF
--- a/api/db/migrations/20250408053119_activity_date_to_datetime/migration.sql
+++ b/api/db/migrations/20250408053119_activity_date_to_datetime/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Activity" ALTER COLUMN "date" SET DATA TYPE TIMESTAMP(3);

--- a/api/db/schema.prisma
+++ b/api/db/schema.prisma
@@ -39,7 +39,7 @@ model Activity {
   mediaId      String?
   notes        String?
   duration     Int?
-  date         DateTime     @default(now()) @db.Date
+  date         DateTime     @default(now())
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
 

--- a/api/src/graphql/activities.sdl.ts
+++ b/api/src/graphql/activities.sdl.ts
@@ -53,7 +53,7 @@ export const schema = gql`
     activityType: ActivityType!
     notes: String
     duration: Int
-    date: DateTime!
+    date: Date! # Changed from DateTime! to Date!
   }
 
   input UpdateActivityInput {

--- a/api/src/lib/TimezoneConverter.ts
+++ b/api/src/lib/TimezoneConverter.ts
@@ -1,0 +1,80 @@
+import { isValid, parse } from 'date-fns'; // Import necessary date-fns functions
+import { formatInTimeZone, toDate } from 'date-fns-tz'; // Use toDate instead of zonedTimeToUtc
+
+/**
+ * Provides utility functions for converting dates and times between UTC
+ * (as stored in the database) and the user's local timezone.
+ */
+export class TimezoneConverter {
+  /**
+   * Converts a date string (assumed to be in 'yyyy-MM-dd' format) representing
+   * a calendar date in the user's timezone into a UTC Date object representing
+   * the start of that day (00:00:00) in the user's timezone.
+   *
+   * @param dateString The date string, e.g., "2025-04-09".
+   * @param timezone The user's IANA timezone name, e.g., "America/New_York".
+   * @returns A Date object representing the corresponding UTC timestamp.
+   * @throws Error if the dateString is invalid or timezone is unrecognized.
+   */
+  static userDateToUtc(dateString: string, timezone: string): Date {
+    // Basic validation of the date string format
+    const parsedDate = parse(dateString, 'yyyy-MM-dd', new Date());
+    if (!isValid(parsedDate)) {
+      throw new Error(
+        `Invalid date string format: ${dateString}. Expected yyyy-MM-dd.`
+      );
+    }
+
+    // Combine date string with start of day time.
+    const dateTimeString = `${dateString}T00:00:00`;
+
+    // Use toDate to parse the string, interpreting it in the user's timezone,
+    // and return the corresponding UTC Date object.
+    try {
+      const utcDate = toDate(dateTimeString, { timeZone: timezone });
+      // Check if the resulting date is valid, as toDate might return Invalid Date
+      if (!isValid(utcDate)) {
+        // This might happen if the timezone is valid but the date/time combination is ambiguous
+        // or invalid within that timezone (e.g., during DST transitions).
+        throw new Error(
+          `Failed to convert date string "${dateString}" to UTC in timezone "${timezone}". Result was an invalid date.`
+        );
+      }
+      return utcDate;
+    } catch (error) {
+      // Catch potential errors from date-fns-tz if timezone is invalid (RangeError)
+      if (error instanceof RangeError) {
+        throw new Error(`Invalid timezone identifier: ${timezone}`);
+      }
+      // Re-throw other unexpected errors
+      throw error;
+    }
+  }
+
+  /**
+   * Formats a UTC Date object (typically from the database) into a string
+   * representing the date and/or time in the user's specified timezone.
+   *
+   * @param utcDate The UTC Date object.
+   * @param timezone The user's IANA timezone name, e.g., "Europe/London".
+   * @param formatString The desired output format string (using date-fns tokens), e.g., "yyyy/MM/dd".
+   * @returns The formatted date/time string in the user's timezone.
+   * @throws Error if the timezone is unrecognized.
+   */
+  static utcToUserFormat(
+    utcDate: Date,
+    timezone: string,
+    formatString: string
+  ): string {
+    try {
+      return formatInTimeZone(utcDate, timezone, formatString);
+    } catch (error) {
+      // Catch potential errors from date-fns-tz if timezone is invalid
+      if (error instanceof RangeError) {
+        throw new Error(`Invalid timezone identifier: ${timezone}`);
+      }
+      // Re-throw other unexpected errors
+      throw error;
+    }
+  }
+}

--- a/api/src/services/activities/activities.ts
+++ b/api/src/services/activities/activities.ts
@@ -2,13 +2,12 @@ import {
   differenceInCalendarDays,
   endOfDay, // Added endOfDay
   isValid, // Added isValid import
-  format, // Added format import
   startOfDay,
   subDays,
   subYears,
 } from 'date-fns';
-// Removed formatInTimeZone import, keep toZonedTime for other functions
-import { toZonedTime } from 'date-fns-tz';
+// Import both timezone functions we need
+import { formatInTimeZone, toZonedTime } from 'date-fns-tz';
 import type {
   ActivityRelationResolvers,
   MutationResolvers,
@@ -64,20 +63,13 @@ export const heatMap: QueryResolvers['heatMap'] = async () => {
       userTimeZone,
       'yyyy/MM/dd'
     );
+
     if (aggregatedData[dateStr]) {
       aggregatedData[dateStr] += activity.duration;
     } else {
       aggregatedData[dateStr] = activity.duration;
     }
   });
-  console.log(
-    // Keep this commented or remove if no longer needed for debugging
-    TimezoneConverter.utcToUserFormat(
-      new Date('2025-04-07T00:00:00.000Z'),
-      userTimeZone,
-      'yyyy/MM/dd'
-    )
-  );
 
   // Transform the aggregated data into the desired format
   const heatMapData = Object.entries(aggregatedData).map(([date, count]) => ({
@@ -278,8 +270,8 @@ export const createActivity: MutationResolvers['createActivity'] = async ({
   }
 
   try {
-    // Format the Date object (UTC midnight) back to 'yyyy-MM-dd' string
-    const dateString = format(input.date, 'yyyy-MM-dd');
+    // Format the Date object explicitly in UTC to get correct 'yyyy-MM-dd' string
+    const dateString = formatInTimeZone(input.date, 'UTC', 'yyyy-MM-dd');
     // Convert the date string to the correct UTC timestamp representing
     // the start of the day in the user's timezone.
     finalDateForDb = TimezoneConverter.userDateToUtc(dateString, userTimeZone);

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "humanize-string": "2.1.0",
     "initials": "^3.1.2",
     "lucide-react": "^0.485.0",

--- a/web/src/components/Activity/ActivityForm/ActivityForm.tsx
+++ b/web/src/components/Activity/ActivityForm/ActivityForm.tsx
@@ -3,7 +3,13 @@ import { useEffect } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
-import { CalendarIcon, Check, ChevronsUpDown, Save } from 'lucide-react';
+import {
+  CalendarIcon,
+  Check,
+  ChevronsUpDown,
+  Loader2,
+  Save,
+} from 'lucide-react';
 import type {
   ActivityType, // <-- Import ActivityType enum
   CreateActivityInput,
@@ -131,6 +137,7 @@ const ActivityForm = (props: ActivityFormProps) => {
                             'col-span-3',
                             !field.value && 'text-muted-foreground'
                           )}
+                          disabled={props.loading}
                         >
                           {field.value ? (
                             format(new Date(field.value), 'PPP')
@@ -161,7 +168,7 @@ const ActivityForm = (props: ActivityFormProps) => {
                 </FormItem>
               )}
             />
-            <ActivityMediaSelect />
+            <ActivityMediaSelect isLoading={props.loading} />
             <FormField
               control={form.control}
               name="activityType"
@@ -178,6 +185,7 @@ const ActivityForm = (props: ActivityFormProps) => {
                             'col-span-3 justify-between lowercase',
                             !field.value && 'text-muted-foreground'
                           )}
+                          disabled={props.loading}
                         >
                           {field.value
                             ? activityTypes.find(
@@ -234,7 +242,7 @@ const ActivityForm = (props: ActivityFormProps) => {
                 <FormItem className="grid grid-cols-4 items-center gap-4">
                   <FormLabel className="text-right">Duration* (min)</FormLabel>
                   <FormControl className="col-span-3">
-                    <Input type="number" {...field} />
+                    <Input type="number" {...field} disabled={props.loading} />
                     {/* <Input placeholder="15" type="number" {...field} /> */}
                   </FormControl>
                   <FormMessage />
@@ -250,6 +258,7 @@ const ActivityForm = (props: ActivityFormProps) => {
                   <FormControl className="col-span-3">
                     <Input
                       placeholder="Optional notes about this activity"
+                      disabled={props.loading}
                       {...field}
                     />
                   </FormControl>
@@ -262,8 +271,14 @@ const ActivityForm = (props: ActivityFormProps) => {
             <Button
               type="submit"
               className="bg-brand-600 hover:bg-brand-700 dark:bg-brand-500 dark:hover:bg-brand-400 text-white dark:text-neutral-900"
+              disabled={props.loading}
             >
-              <Save className="mr-1 h-4 w-4" /> Save Activity
+              {props.loading ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="mr-1 h-4 w-4" />
+              )}
+              Save Activity
             </Button>
           </DialogFooter>
         </Form>

--- a/web/src/components/Activity/ActivityForm/ActivityForm.tsx
+++ b/web/src/components/Activity/ActivityForm/ActivityForm.tsx
@@ -78,10 +78,13 @@ const ActivityForm = (props: ActivityFormProps) => {
 
   const onSubmit: SubmitHandler<ActivitySchemaType> = data => {
     // Create a new object with the correct type, casting activityType and formatting date
+    // Format the date as 'yyyy-MM-dd' string before sending
+    const formattedDate = format(data.date, 'yyyy-MM-dd');
+
     const saveData: CreateActivityInput = {
       ...data,
       activityType: data.activityType as ActivityType, // <-- Explicit cast
-      date: data.date.toISOString(), // <-- Convert Date to ISO string
+      date: formattedDate, // <-- Use the formatted date string
       duration: Number(data.duration), // <-- Explicitly convert duration to number
     };
     props.onSave(saveData); // <-- Use the correctly typed object

--- a/web/src/components/Activity/ActivityForm/fields/MediaSelect.tsx
+++ b/web/src/components/Activity/ActivityForm/fields/MediaSelect.tsx
@@ -47,7 +47,7 @@ const SEARCH_MEDIA_QUERY: TypedDocumentNode<
   }
 `;
 
-const ActivityMediaSelect = () => {
+const ActivityMediaSelect = ({ isLoading }: { isLoading: boolean }) => {
   const [searchValue, setSearchValue] = useState('');
   const debouncedSearch = useDebounce(searchValue, 500);
   const form = useFormContext();
@@ -76,6 +76,7 @@ const ActivityMediaSelect = () => {
                     'col-span-3 justify-between',
                     !field.value && 'text-muted-foreground'
                   )}
+                  disabled={isLoading}
                 >
                   {field.value
                     ? data?.media.find(media => media.slug === field.value)

--- a/yarn.lock
+++ b/yarn.lock
@@ -25052,6 +25052,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     cmdk: "npm:^1.1.1"
     date-fns: "npm:^4.1.0"
+    date-fns-tz: "npm:^3.2.0"
     humanize-string: "npm:2.1.0"
     initials: "npm:^3.1.2"
     lucide-react: "npm:^0.485.0"


### PR DESCRIPTION
This pull request includes significant changes to the handling of date and time fields in the `Activity` model, as well as improvements to date validation and timezone conversion logic. The key changes involve updating the database schema, modifying GraphQL schema definitions, and introducing a new `TimezoneConverter` utility class to handle timezone conversions more effectively.

### Database and Schema Changes:
* [`api/db/migrations/20250408053119_activity_date_to_datetime/migration.sql`](diffhunk://#diff-7fc0beef66d06008379722f7c1e40769cf4821190f84a4fbc33d8bb2ff9c3c3aR1-R2): Changed the `date` column in the `Activity` table to use `TIMESTAMP(3)` data type.
* [`api/db/schema.prisma`](diffhunk://#diff-c64438d7ea5bab0f2c5d6d932f2efbcb1443c42d98b0386effab68723305c07bL42-R42): Updated the `date` field in the `Activity` model to remove the `@db.Date` attribute.

### GraphQL Schema Changes:
* [`api/src/graphql/activities.sdl.ts`](diffhunk://#diff-638d1ad69a0ccfb43f8108219ab38e58658a4f0f18254755aac65234f2572a15L56-R56): Changed the `date` field in the `Activity` type from `DateTime!` to `Date!`.

### Utility Class Introduction:
* [`api/src/lib/TimezoneConverter.ts`](diffhunk://#diff-47178a9435c08ddc439420428b71db9d2dbca2238555857b3c56791f2623ea25R1-R80): Introduced a new `TimezoneConverter` class to handle conversions between user local time and UTC.

### Service and Validation Updates:
* [`api/src/services/activities/activities.ts`](diffhunk://#diff-ed240cd8798892b5242aaae357a9811f3bd06d8552144e25decc21bb45571d00L53-R66): Updated the `createActivity` and `heatMap` functions to use the new `TimezoneConverter` for date handling. [[1]](diffhunk://#diff-ed240cd8798892b5242aaae357a9811f3bd06d8552144e25decc21bb45571d00L53-R66) [[2]](diffhunk://#diff-ed240cd8798892b5242aaae357a9811f3bd06d8552144e25decc21bb45571d00L254-R282)
* [`api/src/services/activities/activityValidation.ts`](diffhunk://#diff-df41a0efb325b2ab44933334e420c5ca56abfa7cac37568f645c803726441607L22-L68): Simplified date validation logic to work with `Date` objects directly, leveraging the new timezone conversion utilities.

### Test Updates:
* [`api/src/services/activities/activities.test.ts`](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaL2-R12): Modified tests to use `Date` objects for the `date` field and added tests for the new timezone conversion logic. [[1]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaL2-R12) [[2]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaR43-R70) [[3]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaR82-R105) [[4]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaR121-R128) [[5]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaL106-R156) [[6]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaL137-R178) [[7]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaR195-R206) [[8]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaL188-R231) [[9]](diffhunk://#diff-20a235d9d27ecae40bf2c8d661a2f7fcbc4473d4ff308da69a8475f95ad375aaR256-R303)