### PR TITLE
Settings test

### DIFF
--- a/api/src/graphql/users.sdl.ts
+++ b/api/src/graphql/users.sdl.ts
@@ -3,7 +3,6 @@ export const schema = gql`
     id: Int!
     email: String!
     name: String!
-    emailVerified: Boolean
     timezone: String
     createdAt: DateTime
     updatedAt: DateTime

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -6,11 +6,12 @@ export const standard = defineScenario<Prisma.UserCreateArgs>({
   user: {
     one: {
       data: {
+        id: 123,
         email: 'String1828080',
+        name: 'String',
         hashedPassword: 'String',
         salt: 'String',
         timezone: 'America/Los_Angeles',
-        updatedAt: '2025-03-30T11:13:26.011Z',
       },
     },
     two: {

--- a/api/src/services/users/users.scenarios.ts
+++ b/api/src/services/users/users.scenarios.ts
@@ -17,9 +17,10 @@ export const standard = defineScenario<Prisma.UserCreateArgs>({
     two: {
       data: {
         email: 'String9662096',
+        name: 'Name2',
         hashedPassword: 'String',
         salt: 'String',
-        timezone: 'America/Los_Angeles',
+        timezone: 'Asia/Tokyo',
         updatedAt: '2025-03-30T11:13:26.011Z',
       },
     },

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,0 +1,38 @@
+import { user } from './users';
+import { StandardScenario } from './users.scenarios';
+
+describe('user', () => {
+  scenario(
+    'returns a user when given a valid id',
+    async (scenario: StandardScenario) => {
+      const result = await user({ id: scenario.user.one.id });
+      expect(result).toMatchObject({
+        email: scenario.user.one.email,
+        name: scenario.user.one.name,
+        timezone: scenario.user.one.timezone,
+      });
+    }
+  );
+
+  scenario(
+    'returns current user when no id provided',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.one);
+      const result = await user({});
+      expect(result).toMatchObject({
+        email: scenario.user.one.email,
+        name: scenario.user.one.name,
+        timezone: scenario.user.one.timezone,
+      });
+    }
+  );
+
+  scenario(
+    'throws error when no id provided and unauthenticated',
+    async (_scenario: StandardScenario) => {
+      mockCurrentUser(null);
+      const fcn = async () => await user();
+      await expect(fcn).rejects.toThrow();
+    }
+  );
+});

--- a/api/src/services/users/users.test.ts
+++ b/api/src/services/users/users.test.ts
@@ -1,4 +1,4 @@
-import { user } from './users';
+import { deleteUser, editUser, user } from './users';
 import { StandardScenario } from './users.scenarios';
 
 describe('user', () => {
@@ -35,4 +35,66 @@ describe('user', () => {
       await expect(fcn).rejects.toThrow();
     }
   );
+});
+
+describe('editUser', () => {
+  scenario('edits a user', async (scenario: StandardScenario) => {
+    mockCurrentUser(scenario.user.one);
+    const result = await editUser({
+      input: {
+        name: scenario.user.two.name,
+        timezone: scenario.user.two.timezone,
+      },
+    });
+
+    expect(result).toMatchObject({
+      email: scenario.user.one.email,
+      name: scenario.user.two.name,
+      timezone: scenario.user.two.timezone,
+    });
+  });
+
+  scenario(
+    'throws error when invalid timezone provided',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.one);
+      await expect(
+        editUser({
+          input: {
+            name: scenario.user.two.name,
+            timezone: 'invalid-timezone',
+          },
+        })
+      ).rejects.toThrow();
+    }
+  );
+
+  scenario(
+    'throws error when invalid name provided',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser(scenario.user.one);
+
+      await expect(
+        editUser({
+          input: {
+            name: 'a',
+            timezone: scenario.user.two.timezone,
+          },
+        })
+      ).rejects.toThrow();
+    }
+  );
+});
+
+describe('deleteUser', () => {
+  scenario('deletes a user', async (scenario: StandardScenario) => {
+    mockCurrentUser(scenario.user.one);
+    await deleteUser();
+
+    const result = await user({
+      id: scenario.user.one.id,
+    });
+
+    expect(result).toBeNull();
+  });
 });

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -83,11 +83,13 @@ export const editUser: MutationResolvers['editUser'] = async ({ input }) => {
   });
 
   // Validate timezone value against known IANA identifiers
-  if (!validTimezones.has(input.timezone)) {
-    throw new Error(
-      'Invalid timezone. Please provide a valid IANA timezone identifier. For example, "America/New_York" or "Europe/London"'
-    );
-  }
+  validateWithSync(() => {
+    if (!validTimezones.has(input.timezone)) {
+      throw new Error(
+        'Invalid timezone. Please provide a valid IANA timezone identifier. For example, "America/New_York" or "Europe/London"'
+      );
+    }
+  });
 
   return db.user.update({
     where: {

--- a/api/src/services/users/users.ts
+++ b/api/src/services/users/users.ts
@@ -15,13 +15,15 @@ import { db } from 'src/lib/db';
 // };
 
 export const user: QueryResolvers['user'] = ({ id }) => {
-  // if there is no id provided, use the current user id
-  const userId = id ? id : context.currentUser.id;
+  // if there is no id provided, use the current user id if available
+  const userId = id || context.currentUser?.id;
 
   // if there's really no id, throw an error
-  if (!userId) {
-    throw new Error('No user id provided');
-  }
+  validateWithSync(() => {
+    if (!userId) {
+      throw new Error('No user id provided');
+    }
+  });
 
   return db.user.findUnique({
     where: { id: userId },

--- a/web/src/components/Settings/AccountSettingsCell/AccountSettingsCell.mock.ts
+++ b/web/src/components/Settings/AccountSettingsCell/AccountSettingsCell.mock.ts
@@ -5,5 +5,6 @@ export const standard = (/* vars, { ctx, req } */) => ({
     id: 42,
     name: 'John Doe',
     email: 'john@example.com',
+    timezone: 'America/New_York',
   },
 });


### PR DESCRIPTION
This pull request includes several changes to the `users` service and related files in the `api` and `web` directories. The changes focus on adding new fields, updating test scenarios, and improving validation logic.

### Schema and Data Changes:
* [`api/src/graphql/users.sdl.ts`](diffhunk://#diff-ed0ee426a5466d8588eed9e7e05078389e0d9f17d707f32f77328c594047b14dL6): Removed the `emailVerified` field from the `User` schema.
* [`api/src/services/users/users.scenarios.ts`](diffhunk://#diff-420e2eb6e928b7e7aaab3c31f3c484d9343944d297b5dff2c3b2cfb2a76f893bR9-R23): Added `id` and `name` fields to the user creation scenario and updated `timezone` values.
* [`web/src/components/Settings/AccountSettingsCell/AccountSettingsCell.mock.ts`](diffhunk://#diff-e863acf6f55f128e88c3c06499135f8185fc184d1e0cef9b32ae3fd82ffa6294R8): Added `timezone` field to the mock data for account settings.

### Test Enhancements:
* [`api/src/services/users/users.test.ts`](diffhunk://#diff-639ba4984a6e19a76b7dbddf766ae2ce31e4c467796c9a2ca7d4df26a61b1b39R1-R100): Added tests for `user`, `editUser`, and `deleteUser` functions, covering various scenarios including valid inputs, invalid inputs, and unauthenticated access.

### Validation Improvements:
* [`api/src/services/users/users.ts`](diffhunk://#diff-91bdfb2da40606ede5edd08a579ab46deedcd9a84eeb89b343139e4127e1f2edL18-R26): Improved validation logic by adding `validateWithSync` calls to ensure that a user ID is provided and the timezone is valid. [[1]](diffhunk://#diff-91bdfb2da40606ede5edd08a579ab46deedcd9a84eeb89b343139e4127e1f2edL18-R26) [[2]](diffhunk://#diff-91bdfb2da40606ede5edd08a579ab46deedcd9a84eeb89b343139e4127e1f2edR86-R92)