### PR TITLE
Remove OAuth login components from LoginPage and SignupForm

### DIFF
--- a/web/src/pages/LoginPage/LoginPage.tsx
+++ b/web/src/pages/LoginPage/LoginPage.tsx
@@ -22,7 +22,6 @@ import { Input } from 'src/components/ui/input';
 
 import logo from './fluencytrail-logo-two-lines.svg';
 import { LoginSchema, LoginSchemaType } from './LoginSchema';
-import OAuthLogin from './OAuthLogin';
 
 const LoginPage = () => {
   const { isAuthenticated, logIn } = useAuth();
@@ -176,7 +175,7 @@ const LoginPage = () => {
                 </div>
               </div>
 
-              <OAuthLogin />
+              {/* <OAuthLogin /> */}
               {/* <div className="mt-6 grid grid-cols-3 gap-3">
                 <Button
                   variant="outline"

--- a/web/src/pages/SignupPage/SignupForm/index.tsx
+++ b/web/src/pages/SignupPage/SignupForm/index.tsx
@@ -16,7 +16,6 @@ import {
 
 import logo from '../fluencytrail-logo-two-lines.svg';
 
-import OAuthSignup from './OAuthSignup';
 import {
   SignupConfirmPasswordField,
   SignupEmailField,
@@ -89,7 +88,7 @@ const SignupForm = ({
             Create Account
           </Button>
         </Form>
-        <OAuthSignup isLoading={isLoading} />
+        {/* <OAuthSignup isLoading={isLoading} /> */}
       </CardContent>
       <CardFooter className="flex flex-col space-y-4 border-t pt-6">
         <div className="text-center text-sm">


### PR DESCRIPTION
This pull request includes changes to the `LoginPage` and `SignupForm` components, focusing on the removal of OAuth login functionality. The most important changes include commenting out the `OAuthLogin` and `OAuthSignup` components and their respective imports.

Changes to `LoginPage` component:

* Commented out the import of `OAuthLogin` from the `LoginPage` component (`web/src/pages/LoginPage/LoginPage.tsx`).
* Commented out the `OAuthLogin` component in the `LoginPage` render method (`web/src/pages/LoginPage/LoginPage.tsx`).

Changes to `SignupForm` component:

* Commented out the import of `OAuthSignup` from the `SignupForm` component (`web/src/pages/SignupPage/SignupForm/index.tsx`).
* Commented out the `OAuthSignup` component in the `SignupForm` render method (`web/src/pages/SignupPage/SignupForm/index.tsx`).