### PR TITLE
feat: close mobile menu on navigation link clicks

### DIFF
--- a/api/src/services/activities/activities.scenarios.ts
+++ b/api/src/services/activities/activities.scenarios.ts
@@ -56,4 +56,4 @@ export const standard = defineScenario<
   },
 });
 
-export type StandardScenario = ScenarioData<Activity>;
+export type StandardScenario = ScenarioData<Activity, 'activity', 'one'>;

--- a/api/src/services/activities/activities.test.ts
+++ b/api/src/services/activities/activities.test.ts
@@ -34,12 +34,73 @@ describe('activities', () => {
     expect(result.length).toEqual(Object.keys(scenario.activity).length);
   });
 
+  scenario(
+    'return activities by languageId',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.activity.one.userId,
+        email: 'email@example.com',
+        name: 'John Doe',
+        timezone: 'UTC', // Mock timezone for date validation
+      });
+
+      const result = await activities({
+        languageId: scenario.activity.one.languageId,
+      });
+
+      expect(result.length).toEqual(Object.keys(scenario.activity).length);
+    }
+  );
+
+  scenario(
+    'return activities but no languageId',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.activity.one.userId,
+        name: 'John Doe',
+        timezone: 'UTC', // Mock timezone for date validation
+        email: 'john@example.com',
+      });
+
+      const result = await activities({
+        itemsPerPage: 10,
+        page: 1,
+      });
+
+      expect(result.length).toEqual(Object.keys(scenario.activity).length);
+    }
+  );
+
+  scenario(
+    'return activities but language id is not on users languages',
+    async (scenario: StandardScenario) => {
+      mockCurrentUser({
+        id: scenario.activity.one.userId,
+        name: 'John Doe',
+        timezone: 'UTC', // Mock timezone for date validation
+        email: 'email@example.com',
+      });
+
+      const result = await activities({
+        languageId: 999, // Assuming this language ID does not exist for the user
+        itemsPerPage: 10,
+        page: 1,
+      });
+
+      expect(result).toEqual([]); // Expect no activities to be returned
+    }
+  );
+});
+
+describe('activity', () => {
   scenario('returns a single activity', async (scenario: StandardScenario) => {
     const result = await activity({ id: scenario.activity.one.id });
 
     expect(result).toEqual(scenario.activity.one);
   });
+});
 
+describe('createActivity', () => {
   scenario('creates an activity', async (scenario: StandardScenario) => {
     mockCurrentUser({
       id: scenario.activity.one.userId,
@@ -263,7 +324,9 @@ describe('activities', () => {
       expect(result.date.toISOString()).toBe('2023-03-01T00:00:00.000Z');
     }
   );
+});
 
+describe('deleteActivity', () => {
   // --- Update and Delete tests remain unchanged ---
   scenario('deletes an activity', async (scenario: StandardScenario) => {
     mockCurrentUser({

--- a/api/src/services/activities/activities.ts
+++ b/api/src/services/activities/activities.ts
@@ -26,7 +26,7 @@ export const activities: QueryResolvers['activities'] = ({
   itemsPerPage = 10,
   page = 1,
   userId = context.currentUser.id,
-  languageId,
+  languageId = null,
 }) => {
   const offset = (page - 1) * itemsPerPage;
 

--- a/web/src/components/Header/MobileMenu.tsx
+++ b/web/src/components/Header/MobileMenu.tsx
@@ -41,6 +41,7 @@ const MobileMenu: FC<MobileMenuProps> = ({ trigger }) => {
             to={routes.home()}
             className="hover:text-brand-600 text-xl font-medium text-neutral-600 transition-colors"
             activeClassName="text-brand-600 hover:text-brand-700 text-xl font-medium transition-colors"
+            onClick={() => setIsOpen(false)}
           >
             Dashboard
           </NavLink>
@@ -48,12 +49,14 @@ const MobileMenu: FC<MobileMenuProps> = ({ trigger }) => {
             to={routes.activity()}
             className="hover:text-brand-600 text-xl font-medium text-neutral-600 transition-colors"
             activeClassName="text-brand-600 hover:text-brand-700 text-xl font-medium transition-colors"
+            onClick={() => setIsOpen(false)}
           >
             Lessons
           </NavLink>
           <Link
             to={routes.home()}
             className="hover:text-brand-600 text-xl font-medium text-neutral-600 transition-colors"
+            onClick={() => setIsOpen(false)}
           >
             My Profile
           </Link>
@@ -71,7 +74,9 @@ const MobileMenu: FC<MobileMenuProps> = ({ trigger }) => {
                 onClick={() => setIsOpen(false)}
                 asChild
               >
-                <Link to={routes.signup()}>Sign up</Link>
+                <Link to={routes.signup()} onClick={() => setIsOpen(false)}>
+                  Sign up
+                </Link>
               </Button>
               <Button
                 variant="outline"
@@ -79,7 +84,9 @@ const MobileMenu: FC<MobileMenuProps> = ({ trigger }) => {
                 onClick={() => setIsOpen(false)}
                 asChild
               >
-                <Link to={routes.login()}>Log in</Link>
+                <Link to={routes.login()} onClick={() => setIsOpen(false)}>
+                  Log in
+                </Link>
               </Button>
             </>
           )}

--- a/web/src/components/Home/HomeProvider.tsx
+++ b/web/src/components/Home/HomeProvider.tsx
@@ -1,0 +1,26 @@
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+const useHomeContext = () => {
+  const context = useContext(HomeContext);
+  if (!context) {
+    throw new Error('useHomeContext must be used within a HomeProvider');
+  }
+  return context;
+};
+
+const HomeContext = createContext({
+  selectedLanguage: null,
+  setSelectedLanguage: (_language: number | null) => {},
+});
+
+const HomeProvider = ({ children }: { children: ReactNode }) => {
+  const [selectedLanguage, setSelectedLanguage] = useState<number | null>(null);
+
+  return (
+    <HomeContext.Provider value={{ selectedLanguage, setSelectedLanguage }}>
+      {children}
+    </HomeContext.Provider>
+  );
+};
+
+export { HomeProvider, useHomeContext };

--- a/web/src/components/Home/ImmersionTrackerCell/ImmersionTrackerCell.tsx
+++ b/web/src/components/Home/ImmersionTrackerCell/ImmersionTrackerCell.tsx
@@ -20,8 +20,8 @@ export const QUERY: TypedDocumentNode<
   FindActivitiesForRecentActivities,
   FindActivitiesForRecentActivitiesVariables
 > = gql`
-  query FindActivitiesForRecentActivities {
-    activities: activities(itemsPerPage: 5, page: 1) {
+  query FindActivitiesForRecentActivities($languageId: Int) {
+    activities: activities(itemsPerPage: 5, page: 1, languageId: $languageId) {
       id
       activityType
       duration

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelector.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelector.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import { ChevronDown, Globe } from 'lucide-react';
 import { GetUserLanguagesForLanguageSelector } from 'types/graphql';
 
@@ -9,13 +11,23 @@ import {
   DropdownMenuTrigger,
 } from 'src/components/ui/dropdown-menu';
 
+import { useHomeContext } from '../HomeProvider';
+
 const LanguageSelector = ({ user }: GetUserLanguagesForLanguageSelector) => {
+  const { selectedLanguage, setSelectedLanguage } = useHomeContext();
+
+  // set the selected language to the primary language if it is not already selected
+  useEffect(() => {
+    if (user.primaryLanguage && selectedLanguage === null) {
+      setSelectedLanguage(user.primaryLanguage.id);
+    }
+  }, [selectedLanguage, setSelectedLanguage, user.primaryLanguage]);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" className="flex items-center gap-2">
           <Globe className="text-brand-600 dark:text-brand-400 h-4 w-4" />
-          <span>English</span>
+          {user.languages.find(lang => lang.id === selectedLanguage)?.name}
           {/* <span className="bg-brand-100 text-brand-800 dark:bg-brand-900 dark:text-brand-200 rounded-full px-1.5 py-0.5 text-xs">
             Fluent
           </span> */}
@@ -27,7 +39,7 @@ const LanguageSelector = ({ user }: GetUserLanguagesForLanguageSelector) => {
           <DropdownMenuItem
             key={language.id}
             className="flex w-32 cursor-pointer items-center justify-between gap-4"
-            // onClick={() => handleSelect(language.code)}
+            onClick={() => setSelectedLanguage(language.id)}
           >
             <div className="flex items-center gap-2">
               <span>{language.name}</span>

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelector.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelector.tsx
@@ -1,0 +1,48 @@
+import { ChevronDown, Globe } from 'lucide-react';
+import { GetUserLanguagesForLanguageSelector } from 'types/graphql';
+
+import { Button } from 'src/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'src/components/ui/dropdown-menu';
+
+const LanguageSelector = ({ user }: GetUserLanguagesForLanguageSelector) => {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="flex items-center gap-2">
+          <Globe className="text-brand-600 dark:text-brand-400 h-4 w-4" />
+          <span>English</span>
+          {/* <span className="bg-brand-100 text-brand-800 dark:bg-brand-900 dark:text-brand-200 rounded-full px-1.5 py-0.5 text-xs">
+            Fluent
+          </span> */}
+          <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {user.languages.map(language => (
+          <DropdownMenuItem
+            key={language.id}
+            className="flex w-32 cursor-pointer items-center justify-between gap-4"
+            // onClick={() => handleSelect(language.code)}
+          >
+            <div className="flex items-center gap-2">
+              <span>{language.name}</span>
+              {/* <span className="bg-brand-100 text-brand-800 dark:bg-brand-900 dark:text-brand-200 rounded-full px-1.5 py-0.5 text-xs">
+                {language.level}
+              </span> */}
+            </div>
+            {/* {language.code === selected && (
+              <Check className="text-brand-600 dark:text-brand-400 h-4 w-4" />
+            )} */}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default LanguageSelector;

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.mock.ts
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.mock.ts
@@ -1,0 +1,30 @@
+import { GetUserLanguagesForLanguageSelector } from 'types/graphql';
+
+// Define your own mock data here:
+export const standard =
+  (/* vars, { ctx, req } */): GetUserLanguagesForLanguageSelector => ({
+    user: {
+      __typename: 'User' as const,
+      languages: [
+        {
+          id: 1,
+          name: 'English',
+          __typename: 'Language' as const,
+        },
+        {
+          id: 2,
+          name: 'Spanish',
+          __typename: 'Language' as const,
+        },
+        {
+          id: 3,
+          name: 'French',
+          __typename: 'Language' as const,
+        },
+      ],
+      primaryLanguage: {
+        id: 1,
+        __typename: 'Language' as const,
+      },
+    },
+  });

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.stories.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Loading, Empty, Failure, Success } from './LanguageSelectorCell'
+import { standard } from './LanguageSelectorCell.mock'
+
+const meta: Meta = {
+  title: 'Cells/LanguageSelectorCell',
+  tags: ['autodocs'],
+}
+
+export default meta
+
+export const loading: StoryObj<typeof Loading> = {
+  render: () => {
+    return Loading ? <Loading /> : <></>
+  },
+}
+
+export const empty: StoryObj<typeof Empty> = {
+  render: () => {
+    return Empty ? <Empty /> : <></>
+  },
+}
+
+export const failure: StoryObj<typeof Failure> = {
+  render: (args) => {
+    return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+  },
+}
+
+export const success: StoryObj<typeof Success> = {
+  render: (args) => {
+    return Success ? <Success {...standard()} {...args} /> : <></>
+  },
+}

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.test.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.test.tsx
@@ -1,0 +1,42 @@
+import { render } from '@redwoodjs/testing/web'
+
+import { Loading, Empty, Failure, Success } from './LanguageSelectorCell'
+import { standard } from './LanguageSelectorCell.mock'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('LanguageSelectorCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure id={42} error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success id={42} languageSelector={standard().languageSelector} />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.test.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.test.tsx
@@ -36,7 +36,7 @@ describe('LanguageSelectorCell', () => {
 
   it('renders Success successfully', async () => {
     expect(() => {
-      render(<Success id={42} languageSelector={standard().languageSelector} />)
+      render(<Success id={42} user={standard().user} />)
     }).not.toThrow()
   })
 })

--- a/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.tsx
+++ b/web/src/components/Home/LanguageSelectorCell/LanguageSelectorCell.tsx
@@ -1,0 +1,68 @@
+import { ChevronDown } from 'lucide-react';
+import type {
+  GetUserLanguagesForLanguageSelector,
+  GetUserLanguagesForLanguageSelectorVariables,
+} from 'types/graphql';
+
+import type {
+  CellFailureProps,
+  CellSuccessProps,
+  TypedDocumentNode,
+} from '@redwoodjs/web';
+
+import { Button } from 'src/components/ui/button';
+
+import LanguageSelector from './LanguageSelector';
+
+export const QUERY: TypedDocumentNode<
+  GetUserLanguagesForLanguageSelector,
+  GetUserLanguagesForLanguageSelectorVariables
+> = gql`
+  # We reused the same query for the LanguageSelectorCell and the LanguageSelector
+  query GetUserLanguagesForLanguageSelector {
+    user: user {
+      languages {
+        name
+        id
+      }
+      primaryLanguage {
+        id
+      }
+    }
+  }
+`;
+
+export const Loading = () => (
+  <Button
+    variant="outline"
+    className="flex w-32 items-center justify-end gap-2"
+  >
+    <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+  </Button>
+);
+
+export const Empty = () => (
+  <Button
+    variant="outline"
+    className="flex w-32 items-center justify-end gap-2"
+  >
+    <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+  </Button>
+);
+
+export const Failure = ({
+  error,
+}: CellFailureProps<GetUserLanguagesForLanguageSelectorVariables>) => (
+  <Button variant="outline" className="flex w-32 items-center gap-2">
+    {error.message}
+  </Button>
+);
+
+export const Success = ({
+  user,
+}: CellSuccessProps<
+  GetUserLanguagesForLanguageSelector,
+  GetUserLanguagesForLanguageSelectorVariables
+>) => {
+  return <LanguageSelector user={user} />;
+};

--- a/web/src/pages/HomePage/HomeCards.tsx
+++ b/web/src/pages/HomePage/HomeCards.tsx
@@ -1,0 +1,29 @@
+import HeatMapCell from 'src/components/Home/HeatMapCell';
+import { useHomeContext } from 'src/components/Home/HomeProvider';
+import ImmersionTrackerCell from 'src/components/Home/ImmersionTrackerCell';
+import StreakCell from 'src/components/Home/StreakCell';
+import TotalTimeCell from 'src/components/Home/TotalTimeCell';
+
+const HomeCards = () => {
+  const { selectedLanguage } = useHomeContext();
+
+  return (
+    <>
+      {/* Activity Heatmap - Central element */}
+      <section>
+        <HeatMapCell />
+      </section>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <StreakCell />
+        <TotalTimeCell />
+      </div>
+
+      <section className="rounded-lg border bg-white p-6 dark:bg-neutral-950">
+        <ImmersionTrackerCell languageId={selectedLanguage} />
+      </section>
+    </>
+  );
+};
+
+export default HomeCards;

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -21,7 +21,7 @@ const HomePage = () => {
           <LanguageSelectorCell />
         </section>
 
-        {/* Note: I had to put this in a diffent component so it can access the context provider */}
+        {/* Note: I had to put this in a different component so it can access the context provider */}
         <HomeCards />
       </div>
     </HomeProvider>

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -1,11 +1,9 @@
 import { Metadata } from '@redwoodjs/web';
 
-import HeatMapCell from 'src/components/Home/HeatMapCell';
 import { HomeProvider } from 'src/components/Home/HomeProvider';
-import ImmersionTrackerCell from 'src/components/Home/ImmersionTrackerCell';
 import LanguageSelectorCell from 'src/components/Home/LanguageSelectorCell';
-import StreakCell from 'src/components/Home/StreakCell';
-import TotalTimeCell from 'src/components/Home/TotalTimeCell';
+
+import HomeCards from './HomeCards';
 
 const HomePage = () => {
   return (
@@ -23,19 +21,8 @@ const HomePage = () => {
           <LanguageSelectorCell />
         </section>
 
-        {/* Activity Heatmap - Central element */}
-        <section>
-          <HeatMapCell />
-        </section>
-
-        <div className="grid gap-6 md:grid-cols-2">
-          <StreakCell />
-          <TotalTimeCell />
-        </div>
-
-        <section className="rounded-lg border bg-white p-6 dark:bg-neutral-950">
-          <ImmersionTrackerCell />
-        </section>
+        {/* Note: I had to put this in a diffent component so it can access the context provider */}
+        <HomeCards />
       </div>
     </HomeProvider>
   );

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -1,14 +1,15 @@
-// import { Link, routes } from '@redwoodjs/router'
 import { Metadata } from '@redwoodjs/web';
 
 import HeatMapCell from 'src/components/Home/HeatMapCell';
+import { HomeProvider } from 'src/components/Home/HomeProvider';
 import ImmersionTrackerCell from 'src/components/Home/ImmersionTrackerCell';
+import LanguageSelectorCell from 'src/components/Home/LanguageSelectorCell';
 import StreakCell from 'src/components/Home/StreakCell';
 import TotalTimeCell from 'src/components/Home/TotalTimeCell';
 
 const HomePage = () => {
   return (
-    <>
+    <HomeProvider>
       <Metadata title="Home" description="Home page" />
 
       <div className="flex flex-col gap-6">
@@ -19,11 +20,7 @@ const HomePage = () => {
               Track your language learning progress
             </p>
           </div>
-          {/* <LanguageSelector
-          languages={languages}
-          currentLanguage={currentLanguage}
-          onLanguageChange={setCurrentLanguage}
-        /> */}
+          <LanguageSelectorCell />
         </section>
 
         {/* Activity Heatmap - Central element */}
@@ -40,7 +37,7 @@ const HomePage = () => {
           <ImmersionTrackerCell />
         </section>
       </div>
-    </>
+    </HomeProvider>
   );
 };
 


### PR DESCRIPTION
closes #52 

This pull request includes changes to the `MobileMenu` component in the `web/src/components/Header/MobileMenu.tsx` file to improve the user experience by closing the menu when navigation links are clicked. The most important changes include adding `onClick` handlers to various navigation links to set the `isOpen` state to false.

Improvements to user experience:

* Added `onClick` handlers to `NavLink` components for "Dashboard", "Lessons", and "My Profile" to close the menu when these links are clicked.
* Modified `Link` components for "Sign up" and "Log in" buttons to include `onClick` handlers that close the menu when these links are clicked.