### PR TITLE
feat: restrict custom media search to the user who created it

### DIFF
--- a/api/src/services/medias/mediamanager/custom-media-adapter.ts
+++ b/api/src/services/medias/mediamanager/custom-media-adapter.ts
@@ -34,6 +34,7 @@ export class CustomMediaFetcher implements MediaFetcher {
             contains: query,
             mode: 'insensitive',
           },
+          userId: context.currentUser.id,
         },
         take: 10, // Limit to 10 results as specified
       });

--- a/api/src/services/medias/mediamanager/index.ts
+++ b/api/src/services/medias/mediamanager/index.ts
@@ -165,10 +165,9 @@ class MediaManager {
       return this.mapMediaToDto(existingMedia);
     }
 
-    // TODO: Custom media should only be searchable by the user who created it
     // If not found in Media table, try CustomMedia
     const customMedia = await db.customMedia.findUnique({
-      where: { slug },
+      where: { slug, userId: context.currentUser.id },
       include: {
         User: {
           select: {


### PR DESCRIPTION
This pull request ensures that custom media is only accessible to the user who created it by adding user-specific filtering to media queries. The changes enhance security and privacy for custom media data.

### Security and privacy improvements:

* [`api/src/services/medias/mediamanager/custom-media-adapter.ts`](diffhunk://#diff-43ddb5b5876e30f45f7b2f302301476ef374b87dcd75f975d6eb813519484062R37): Added a filter to include `userId` in the query, ensuring that only the current user's custom media is fetched.
* [`api/src/services/medias/mediamanager/index.ts`](diffhunk://#diff-4e5fc55d6cdfeb405310caa7b75d0efa2ad8591ac58e0df090c37a0dc67d6229L168-R170): Updated the `findUnique` query for custom media to include a `userId` filter, restricting access to the user who created the media. Removed a TODO comment as the functionality is now implemented.