### PR TITLE
refactor: update elapsed time calculation to consider user's timezone

### DIFF
--- a/web/src/components/Header/HeaderTimer/HeaderTimer.tsx
+++ b/web/src/components/Header/HeaderTimer/HeaderTimer.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 
+import { formatInTimeZone } from 'date-fns-tz';
 import { Clock } from 'lucide-react';
 import { GetActivityTimerForHeader } from 'types/graphql';
 
+import { useAuth } from 'src/auth';
 import { Button } from 'src/components/ui/button';
 import { useActivityModal } from 'src/layouts/ProvidersLayout/Providers/ActivityProvider';
 
@@ -12,6 +14,7 @@ interface HeaderTimerProps {
 
 const HeaderTimer = ({ activeTimer }: HeaderTimerProps) => {
   const { setActiveTimerModalOpen } = useActivityModal();
+  const { currentUser } = useAuth();
 
   const [elapsed, setElapsed] = useState(0);
   const startTime = useMemo(
@@ -21,7 +24,15 @@ const HeaderTimer = ({ activeTimer }: HeaderTimerProps) => {
 
   useEffect(() => {
     const calculateElapsed = () => {
-      setElapsed(Date.now() - startTime);
+      // Get the current time in the user's timezone
+      const now = new Date(
+        formatInTimeZone(
+          new Date(),
+          currentUser.timezone,
+          'yyyy-MM-dd HH:mm:ss'
+        )
+      ).getTime();
+      setElapsed(now - startTime);
     };
 
     // Immediate first update
@@ -32,7 +43,7 @@ const HeaderTimer = ({ activeTimer }: HeaderTimerProps) => {
 
     // Cleanup on unmount or startTime change
     return () => clearInterval(interval);
-  }, [startTime]);
+  }, [startTime, currentUser.timezone]);
 
   const formatTime = (ms: number) => {
     const hours = Math.floor(ms / 3600000);


### PR DESCRIPTION
This pull request introduces timezone-aware calculations for elapsed time in two components: `CurrentActivityTimerModal` and `HeaderTimer`. The changes ensure that elapsed time is calculated based on the user's timezone, improving accuracy for users in different time zones.

### Timezone-aware elapsed time calculation:

* `web/src/components/ActivityTimer/CurrentActivityTimerCell/CurrentActivityTimerModal.tsx`:
  - Added `formatInTimeZone` from `date-fns-tz` and `useAuth` to access the user's timezone.
  - Updated the `calculateElapsed` function to use the user's timezone for determining the current time.
  - Added `currentUser.timezone` as a dependency to the `useEffect` hook to ensure recalculation when the timezone changes.

* `web/src/components/Header/HeaderTimer/HeaderTimer.tsx`:
  - Added `formatInTimeZone` from `date-fns-tz` and `useAuth` to access the user's timezone.
  - Updated the `calculateElapsed` function to use the user's timezone for determining the current time.
  - Added `currentUser.timezone` as a dependency to the `useEffect` hook to ensure recalculation when the timezone changes.